### PR TITLE
ADD: kamp-grep script (interactive grep) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kampliment is a tool to control [Kakoune](https://github.com/mawww/kakoune) edit
 
 Requires [Rust](https://www.rust-lang.org) installed on your system.
 
-Clone the repository and run `cargo install`
+Clone the repository and run `cargo install --path .`
 
 ## Kakoune integration
 
@@ -19,6 +19,17 @@ evaluate-commands %sh{
     kamp init -a -e EDITOR='kamp edit'
 }
 ```
+
+## Provided scripts
+
+The [scripts](scripts) need to be added to `$PATH` in order use them
+
+| script                                   | function                         |
+| ---------------------------------------- | -------------------------------- |
+| [`kamp-buffers`](scripts/kamp-buffers)   | pick buffers                     |
+| [`kamp-files`](scripts/kamp-files)       | pick files                       |
+| [`kamp-gitls`](scripts/kamp-gitls)       | pick from `git ls-files`         |
+| [`kamp-sessions`](scripts/kamp-sessions) | attach session and pick a buffer |
 
 ### Kakoune mappings example
 
@@ -47,15 +58,6 @@ alias kcd-pwd='cd "$(kamp get sh pwd)"'
 alias kcd-buf='cd "$(dirname $(kamp get val buffile))"'
 alias kft='kamp get -b \* opt filetype | sort | uniq' # list file types you're working on
 ```
-
-## Provided scripts
-
-| script                                   | function                         |
-| ---------------------------------------- | -------------------------------- |
-| [`kamp-buffers`](scripts/kamp-buffers)   | pick buffers                     |
-| [`kamp-files`](scripts/kamp-files)       | pick files                       |
-| [`kamp-gitls`](scripts/kamp-gitls)       | pick from `git ls-files`         |
-| [`kamp-sessions`](scripts/kamp-sessions) | attach session and pick a buffer |
 
 ## Similar projects
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ The [scripts](scripts) need to be added to `$PATH` in order use them
 
 | script                                   | function                         |
 | ---------------------------------------- | -------------------------------- |
-| [`kamp-buffers`](scripts/kamp-buffers)   | pick buffers                     |
-| [`kamp-files`](scripts/kamp-files)       | pick files                       |
-| [`kamp-gitls`](scripts/kamp-gitls)       | pick from `git ls-files`         |
+| [`kamp-buffers`](scripts/kamp-buffers)   | pick buffers (fzf)               |
+| [`kamp-files`](scripts/kamp-files)       | pick files (fzf)                 |
+| [`kamp-gitls`](scripts/kamp-gitls)       | pick from `git ls-files` (fzf)   |
 | [`kamp-sessions`](scripts/kamp-sessions) | attach session and pick a buffer |
+| [`kamp-grep`](scripts/kamp-grep)         | grep interactively with fzf      |
 
 ### Kakoune mappings example
 
@@ -37,6 +38,7 @@ The [scripts](scripts) need to be added to `$PATH` in order use them
 map global normal -docstring 'terminal' <c-t> ': connect terminal<ret>'
 map global normal -docstring 'files'    <c-f> ': connect terminal-popup kamp-files<ret>'
 map global normal -docstring 'buffers'  <c-b> ': connect terminal-popup kamp-buffers<ret>'
+map global normal -docstring 'grep'     <c-g> ': connect terminal-popup kamp-grep<ret>'
 ```
 
 ## Shell integration

--- a/scripts/kamp-grep
+++ b/scripts/kamp-grep
@@ -17,4 +17,31 @@ for path do
   echo "$path" >> "$PATHS_PATH"
 done
 
-SHELL=sh fzf --phony --delimiter ':' --ansi --bind 'change:reload(while read path; do set -- "$@" "$path"; done < "$PATHS_PATH"; rg --color=always --column --with-filename --fixed-strings -- {q} "$@" || true),enter:execute(kamp edit {1} +{2}:{3})+abort' --preview 'highlight_line={2} line_range_begin=$((line = highlight_line - (FZF_PREVIEW_LINES / 4) && line < 1 ? 1 : line)) line_range_end=$((line_range_begin + FZF_PREVIEW_LINES)) && bat --style=numbers --color=always --line-range "$line_range_begin:$line_range_end" --highlight-line {2} {1} 2> /dev/null' --header='Select a file to open' --prompt='(g)>'
+SHELL=sh \
+fzf \
+  --phony \
+  --delimiter ':' \
+  --ansi \
+  --bind 'change:reload(
+            while read path;
+              do set -- "$@" "$path";
+            done < "$PATHS_PATH";
+            rg \
+              --color=always \
+              --column \
+              --with-filename \
+              --fixed-strings -- {q} "$@" || true \
+          ),enter:execute(
+            kamp edit {1} +{2}:{3}
+          )+abort' \
+  --preview '
+      highlight_line={2} \
+      line_range_begin=$((line = highlight_line - (FZF_PREVIEW_LINES / 4) && line < 1 ? 1 : line)) \
+      line_range_end=$((line_range_begin + FZF_PREVIEW_LINES)) \
+      && bat \
+        --style=numbers \
+        --color=always \
+        --line-range "$line_range_begin:$line_range_end" \
+        --highlight-line {2} {1} 2> /dev/null' \
+  --header='Select a file to open' \
+  --prompt='(g)>'

--- a/scripts/kamp-grep
+++ b/scripts/kamp-grep
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Open files by content.
+#
+# Usage:
+#
+# kamp-grep [paths]
+
+# – fzf (https://github.com/junegunn/fzf)
+# – ripgrep (https://github.com/BurntSushi/ripgrep)
+
+# Not pretty but robust.
+# https://github.com/junegunn/fzf/issues/2581
+export PATHS_PATH=$(mktemp)
+trap 'rm "$PATHS_PATH"' EXIT
+for path do
+  echo "$path" >> "$PATHS_PATH"
+done
+
+SHELL=sh fzf --phony --delimiter ':' --ansi --bind 'change:reload(while read path; do set -- "$@" "$path"; done < "$PATHS_PATH"; rg --color=always --column --with-filename --fixed-strings -- {q} "$@" || true),enter:execute(kamp edit {1} +{2}:{3})+abort' --preview 'highlight_line={2} line_range_begin=$((line = highlight_line - (FZF_PREVIEW_LINES / 4) && line < 1 ? 1 : line)) line_range_end=$((line_range_begin + FZF_PREVIEW_LINES)) && bat --style=numbers --color=always --line-range "$line_range_begin:$line_range_end" --highlight-line {2} {1} 2> /dev/null' --header='Select a file to open' --prompt='(g)>'


### PR DESCRIPTION
A script to grep with ripgrep and fzf interactively, and open the file in a new buffer with the cursor at the selected result's line/column.

note: I branched from update-readme to avoid the need of a third PR for the changes to README.md regarding kamp-grep