### PR TITLE
FIX: set SHELL in kamp-grep, for non posix users

### DIFF
--- a/scripts/kamp-grep
+++ b/scripts/kamp-grep
@@ -15,6 +15,9 @@
 
 # - bat (https://github.com/sharkdp/bat)
 
+# define SHELL so --preview arguments do not error if current SHELL is not POSIX
+SHELL=/bin/sh
+
 # $@ is meant to pass extra options to rg, not a query and not a path
 rg_cmd="rg --color=always --column --fixed-strings $@"
 


### PR DESCRIPTION
Why?
fzf's `--preview` uses `SHELL`, and fish-shell will error in the previewer due to the use of `=`.

How?
Add `SHELL=/bin/sh` , so the `--preview` uses `sh` instead of the user defined `SHELL`.