### PR TITLE
feat(scripts): add kamp-filetypes, and kamp-lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ evaluate-commands %sh{
 
 The [scripts](scripts) need to be added to `$PATH` in order to use them.
 
-| script                                   | function                         |
-| ---------------------------------------- | -------------------------------- |
-| [`kamp-buffers`](scripts/kamp-buffers)   | pick buffers (fzf)               |
-| [`kamp-files`](scripts/kamp-files)       | pick files (fzf)                 |
-| [`kamp-gitls`](scripts/kamp-gitls)       | pick from `git ls-files` (fzf)   |
-| [`kamp-sessions`](scripts/kamp-sessions) | attach session and pick a buffer |
-| [`kamp-grep`](scripts/kamp-grep)         | grep interactively with fzf      |
-| [`kamp-fifo`](scripts/kamp-fifo)         | pipe stdin into fifo buffer      |
+| script                                     | function                         |
+| ------------------------------------------ | -------------------------------- |
+| [`kamp-buffers`](scripts/kamp-buffers)     | pick buffers (fzf)               |
+| [`kamp-files`](scripts/kamp-files)         | pick files (fzf)                 |
+| [`kamp-filetypes`](scripts/kamp-filetypes) | set filetype (fzf)               |
+| [`kamp-gitls`](scripts/kamp-gitls)         | pick from `git ls-files` (fzf)   |
+| [`kamp-lines`](scripts/kamp-lines)         | search lines in buffer (fzf)     |
+| [`kamp-sessions`](scripts/kamp-sessions)   | attach session and pick a buffer |
+| [`kamp-grep`](scripts/kamp-grep)           | grep interactively with fzf      |
+| [`kamp-fifo`](scripts/kamp-fifo)           | pipe stdin into fifo buffer      |
 
 ### Kakoune mappings example
 

--- a/scripts/kamp-filetypes
+++ b/scripts/kamp-filetypes
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# pick filetype from Kakoune's runtime dir and set in current buffer
+#
+# requires:
+# - fzf (https://github.com/junegunn/fzf)
+
+ft_dir="$(kamp get val runtime)/rc/filetype"
+
+find "$ft_dir"/*.kak -type f -exec basename -s .kak {} \; |
+	fzf --no-preview --prompt 'filetypes> ' |
+	xargs -I {} kamp send 'set buffer filetype {}'

--- a/scripts/kamp-lines
+++ b/scripts/kamp-lines
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# jump to line in buffer
+#
+# requires:
+# - fzf (https://github.com/junegunn/fzf)
+
+kamp cat |
+	nl -ba -s' │ ' |
+	fzf --no-preview --prompt 'lines> ' |
+	awk '{print $1}' |
+	xargs -r -I {} kamp send "execute-keys '<esc>{}g'"


### PR DESCRIPTION
Additional `kamp-filetypes` and `kamp-lines` scripts borrowed from [kks](https://github.com/kkga/kks/tree/main/scripts)