### PR TITLE
Add nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Requires [Rust](https://www.rust-lang.org) installed on your system.
 
 Clone the repository and run `cargo install --path .`
 
+### Nix
+
+With nix-env:
+
+```shell-script
+nix-env -iA kamp
+```
+
+With modern nix command:
+
+```shell-script
+nix profile install nixpkgs#kamp
+```
+
 ## Kakoune integration
 
 Add following definition into your kakrc.


### PR DESCRIPTION
I recently added [kamp to nixpkgs repository](https://github.com/NixOS/nixpkgs/pull/347089) now I would like to add useful information of how to install kamp using nix to the README.md.