### PR TITLE
refactoring: changed how temporal fifo paths are contructed

### DIFF
--- a/src/kamp/cmd/init.rs
+++ b/src/kamp/cmd/init.rs
@@ -8,8 +8,8 @@ define-command -hidden -override kamp-init %{
     declare-option -hidden str kamp_out
     declare-option -hidden str kamp_err
     evaluate-commands %sh{
-        kamp_out="${TMPDIR:-/tmp/}kamp-${kak_session}.out"
-        kamp_err="${TMPDIR:-/tmp/}kamp-${kak_session}.err"
+        kamp_out="${TMPDIR:-/tmp}/kamp-${kak_session}.out"
+        kamp_err="${TMPDIR:-/tmp}/kamp-${kak_session}.err"
         mkfifo "$kamp_out" "$kamp_err"
         printf 'set global kamp_%s %s\n' out "$kamp_out" err "$kamp_err"
     }


### PR DESCRIPTION
Usually TMPDIR variable does not contain trailing slash, and It will cause an **error that freeze kakoune** if it's been declared this way.

This PR just correct the code generated by kamp init to avoid the error, If you wish I will look further to discover the error and try to fix it. Feel free to create issue and assign me. :smile: 

## Reproduce error:
`export TMPDIR=$(mktemp -d)`
`kak`
`:kamp-connect terminal`
`kamp list`
**At this point my kakoune session gets freeze and kamp list prints `Error: receiving on an empty and disconnected channel`.**